### PR TITLE
Refactor: Initial website styling improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 @import url("sites/all/modules/biblio/biblio.css%3Fpaddsf.css");
 </style>
 <link type="text/css" rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" media="all" />
-<link type="text/css" rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" media="all" />
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous">
 <style type="text/css" media="all">
 @import url("sites/cienciaaberta.ubatuba.cc/themes/cienciaaberta/js/meanmenu/meanmenu.css%3Fpaddsf.css");
 </style>
@@ -127,53 +127,53 @@ jQuery(document).ready(function($) {
 		});
 //--><!]]>
 </script>
-<script type="text/javascript" src="sites/cienciaaberta.ubatuba.cc/themes/cienciaaberta/js/meanmenu/jquery.meanmenu.fork.js%3Fpaddsf"></script>
+<!-- <script type="text/javascript" src="sites/cienciaaberta.ubatuba.cc/themes/cienciaaberta/js/meanmenu/jquery.meanmenu.fork.js%3Fpaddsf"></script>
 <script type="text/javascript">
-<!--//--><![CDATA[//><!--
-jQuery(document).ready(function($) {
+//--><![CDATA[//><!--
+// jQuery(document).ready(function($) {
 
-			$("#main-navigation .sf-menu, #main-navigation .content>ul.menu, #main-navigation ul.main-menu").wrap("<div class='meanmenu-wrapper'></div>");
-			$("#main-navigation .meanmenu-wrapper").meanmenu({
-				meanScreenWidth: "767",
-				meanRemoveAttrs: true,
-				meanMenuContainer: "#header-inside",
-				meanMenuClose: ""
-			});
+// 			$("#main-navigation .sf-menu, #main-navigation .content>ul.menu, #main-navigation ul.main-menu").wrap("<div class='meanmenu-wrapper'></div>");
+// 			$("#main-navigation .meanmenu-wrapper").meanmenu({
+// 				meanScreenWidth: "767",
+// 				meanRemoveAttrs: true,
+// 				meanMenuContainer: "#header-inside",
+// 				meanMenuClose: ""
+// 			});
 
-			$("#header-top .sf-menu, #header-top .content>ul.menu").wrap("<div class='header-top-meanmenu-wrapper'></div>");
-			$("#header-top .header-top-meanmenu-wrapper").meanmenu({
-				meanScreenWidth: "767",
-				meanRemoveAttrs: true,
-				meanMenuContainer: "#header-top-inside",
-				meanMenuClose: ""
-			});
+// 			$("#header-top .sf-menu, #header-top .content>ul.menu").wrap("<div class='header-top-meanmenu-wrapper'></div>");
+// 			$("#header-top .header-top-meanmenu-wrapper").meanmenu({
+// 				meanScreenWidth: "767",
+// 				meanRemoveAttrs: true,
+// 				meanMenuContainer: "#header-top-inside",
+// 				meanMenuClose: ""
+// 			});
 
-		});
+// 		});
 //--><!]]>
-</script>
+// </script> -->
 <script type="text/javascript">
 <!--//--><![CDATA[//><!--
 jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"cienciaaberta","theme_token":"3u9Vt8QxgHpydiO8wbeZs1aFmmmym1Ie0G7Df6t7qxg","js":{"misc\/jquery.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"public:\/\/languages\/pt-br_SYeuRH3X3f_UgLzqznTVyLg5pDzTXooqJjf94TfwOqI.js":1,"sites\/all\/modules\/disqus\/js\/disqus.js":1,"sites\/all\/modules\/google_analytics\/googleanalytics.js":1,"0":1,"1":1,"2":1,"sites\/cienciaaberta.ubatuba.cc\/themes\/cienciaaberta\/js\/meanmenu\/jquery.meanmenu.fork.js":1,"3":1},"css":{"modules\/system\/system.base.css":1,"modules\/system\/system.menus.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"modules\/aggregator\/aggregator.css":1,"sites\/all\/modules\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/date\/date_api\/date.css":1,"sites\/all\/modules\/date\/date_popup\/themes\/datepicker.1.7.css":1,"sites\/all\/modules\/date\/date_repeat_field\/date_repeat_field.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"modules\/search\/search.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/youtube\/css\/youtube.css":1,"sites\/all\/modules\/views\/css\/views.css":1,"sites\/all\/modules\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/biblio\/biblio.css":1,"\/\/maxcdn.bootstrapcdn.com\/font-awesome\/4.2.0\/css\/font-awesome.min.css":1,"\/\/maxcdn.bootstrapcdn.com\/bootstrap\/3.2.0\/css\/bootstrap.min.css":1,"sites\/cienciaaberta.ubatuba.cc\/themes\/cienciaaberta\/js\/meanmenu\/meanmenu.css":1,"sites\/cienciaaberta.ubatuba.cc\/themes\/cienciaaberta\/bootstrap\/css\/bootstrap.css":1,"sites\/cienciaaberta.ubatuba.cc\/themes\/cienciaaberta\/style.css":1,"sites\/cienciaaberta.ubatuba.cc\/themes\/cienciaaberta\/style-green.css":1,"sites\/cienciaaberta.ubatuba.cc\/themes\/cienciaaberta\/fonts\/lato-font.css":1,"sites\/cienciaaberta.ubatuba.cc\/themes\/cienciaaberta\/fonts\/sourcecodepro-font.css":1,"sites\/cienciaaberta.ubatuba.cc\/themes\/cienciaaberta\/fonts\/ptserif-blockquote-font.css":1,"sites\/cienciaaberta.ubatuba.cc\/themes\/cienciaaberta\/ie9.css":1,"sites\/cienciaaberta.ubatuba.cc\/themes\/cienciaaberta\/local.css":1}},"disqusComments":"cienciaabertaubatuba","googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip"}});
 //--><!]]>
 </script>
 </head>
-<body class="html front not-logged-in one-sidebar sidebar-second page-home no-banner sff-7 slff-7 hff-7 pff-7 form-style-1" >
+<body class="html front not-logged-in one-sidebar sidebar-second page-home no-banner form-style-1" >
   <div id="skip-link">
     <a href="index.html#main-content" class="element-invisible element-focusable">Pular para o conteúdo principal</a>
   </div>
     <div id="toTop"><i class="fa fa-angle-up"></i></div>
 
 <!-- #header-top -->
-<div id="header-top" class="clearfix">
+<!-- <div id="header-top" class="clearfix">
     <div class="container">
 
-        <!-- #header-top-inside -->
+        
         <div id="header-top-inside" class="clearfix">
             <div class="row">
             
                         
                         <div class="col-md-12">
-                <!-- #header-top-right -->
+                
                 <div id="header-top-right" class="clearfix">
                     <div class="header-top-area">                    
                           <div class="region region-header-top-right">
@@ -190,27 +190,27 @@ jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":
   </div>
                     </div>
                 </div>
-                <!-- EOF:#header-top-right -->
+                
             </div>
                         
             </div>
         </div>
-        <!-- EOF: #header-top-inside -->
+        
 
     </div>
-</div>
+</div> -->
 <!-- EOF: #header-top -->    
 
 <!-- #header -->
-<header id="header"  role="banner" class="clearfix">
+<!-- <header id="header"  role="banner" class="clearfix">
     <div class="container">
         
-        <!-- #header-inside -->
+        
         <div id="header-inside" class="clearfix">
             <div class="row">
             
                 <div class="col-md-4">
-                    <!-- #header-inside-left -->
+                    
                     <div id="header-inside-left" class="clearfix">
 
                                         <div id="logo">
@@ -222,14 +222,14 @@ jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":
                       
 
                     </div>
-                    <!-- EOF:#header-inside-left -->
+                    
                 </div>
                 
                 <div class="col-md-8">
-                    <!-- #header-inside-right -->
+                    
                     <div id="header-inside-right" class="clearfix">
 
-                        <!-- #main-navigation -->
+                        
                         <div id="main-navigation" class="clearfix">
                             <nav role="navigation"> 
                                                                   <div class="region region-navigation">
@@ -243,20 +243,67 @@ jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":
   </div>
                                                             </nav>
                         </div>
-                        <!-- EOF: #main-navigation -->
+                        
 
                     </div>
-                    <!-- EOF:#header-inside-right -->                        
+                                            
                 </div>
          
             </div>
         </div>
-        <!-- EOF: #header-inside -->
+        
 
     </div>
-</header>
+</header> -->
 <!-- EOF: #header -->
 
+<nav class="navbar navbar-expand-lg navbar-light bg-light border-bottom">
+  <div class="container">
+    <a class="navbar-brand" href="index.html">
+      <img src="sites/cienciaaberta.ubatuba.cc/files/logo.png" alt="Início" style="max-height: 40px;" />
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNavDropdown">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="index.html">Início</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="ciência-aberta-ubatuba.html">O projeto</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="blog.html" title="Weblog do projeto Ciência Aberta Ubatuba">Blog</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="contact.html" title="Entre em contato com o projeto">Contato</a>
+        </li>
+      </ul>
+
+      <!-- Search Form -->
+      <form class="d-flex ms-auto" role="search">
+        <input class="form-control me-2" type="search" placeholder="Pesquisar" aria-label="Pesquisar">
+        <button class="btn btn-outline-success" type="submit">
+          <i class="fa fa-search"></i> <span class="d-lg-none ms-2">Pesquisar</span>
+        </button>
+      </form>
+
+      <!-- Language Switcher -->
+      <ul class="navbar-nav"> <!-- No ms-auto needed here -->
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarLangDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <i class="fa fa-globe"></i> <span class="d-lg-none ms-2">Idioma</span>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarLangDropdown">
+            <li><a class="dropdown-item" href="#">Português (BR)</a></li>
+            <li><a class="dropdown-item" href="#">English (EN)</a></li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
 
 <!-- #page -->
 <div id="page" class="clearfix">
@@ -267,7 +314,7 @@ jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":
     
     <!-- #main-content -->
     <div id="main-content">
-        <div class="container">
+        <div class="container py-5">
 
             <div class="row">
 
@@ -628,5 +675,6 @@ jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":
 	
 	</div>
 </div><!-- EOF:#subfooter -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/sites/cienciaaberta.ubatuba.cc/themes/cienciaaberta/fonts/lato-font.css
+++ b/sites/cienciaaberta.ubatuba.cc/themes/cienciaaberta/fonts/lato-font.css
@@ -1,1 +1,3 @@
+@import url('https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap');
 @import url(http://fonts.googleapis.com/css?family=Lato:300,400,700,900,300italic,400italic,700italic,900italic);

--- a/sites/cienciaaberta.ubatuba.cc/themes/cienciaaberta/style.css
+++ b/sites/cienciaaberta.ubatuba.cc/themes/cienciaaberta/style.css
@@ -1,4 +1,5 @@
 /* Fonts families */
+/* 
 body.pff-1, .pff-1 input, .pff-1 select, .pff-1 textarea, .pff-1 blockquote, .pff-1 .ui-widget { font-family: 'Merriweather', Georgia, Times New Roman, Serif; }
 body.pff-2, .pff-2 input, .pff-2 select, .pff-2 textarea, .pff-2 blockquote, .pff-2 .ui-widget { font-family: 'Source Sans Pro', Helvetica Neue, Arial, Sans-serif; }
 body.pff-3, .pff-3 input, .pff-3 select, .pff-3 textarea, .pff-3 blockquote, .pff-3 .ui-widget { font-family: 'Ubuntu', Helvetica Neue, Arial, Sans-serif; }
@@ -30,7 +31,9 @@ body.pff-28, .pff-28 input, .pff-28 select, .pff-28 textarea, .pff-28 blockquote
 body.pff-29, .pff-29 input, .pff-29 select, .pff-29 textarea, .pff-29 blockquote, .pff-29 .ui-widget { font-family: 'Volkhov', Georgia, Times, Times New Roman, Serif; }
 body.pff-30, .pff-30 input, .pff-30 select, .pff-30 textarea, .pff-30 blockquote, .pff-30 .ui-widget { font-family: Times, Times New Roman, Serif; }
 body.pff-31, .pff-31 input, .pff-31 select, .pff-31 textarea, .pff-31 blockquote, .pff-31 .ui-widget { font-family: 'Alegreya SC', Georgia, Times, Times New Roman, Serif; }
+*/
 
+/*
 .hff-1 h1,.hff-1 h2,.hff-1 h3,.hff-1 h4,.hff-1 h5,.hff-1 h6, .hff-1 .title-teaser-text .title, .sff-1 #site-name, 
 .sff-1 #subfooter-site-name, .slff-1 #site-slogan { font-family: 'Merriweather', Georgia, Times New Roman, Serif; }
 .hff-2 h1,.hff-2 h2,.hff-2 h3,.hff-2 h4,.hff-2 h5,.hff-2 h6, .hff-2 .title-teaser-text .title, .sff-2 #site-name, 
@@ -93,6 +96,7 @@ body.pff-31, .pff-31 input, .pff-31 select, .pff-31 textarea, .pff-31 blockquote
 .sff-30 #subfooter-site-name, .slff-30 #site-slogan { font-family: Times, Times New Roman, Serif; }
 .hff-31 h1,.hff-31 h2,.hff-31 h3,.hff-31 h4,.hff-31 h5,.hff-31 h6, .hff-31 .title-teaser-text .title, .sff-31 #site-name, 
 .sff-31 #subfooter-site-name, .slff-31 #site-slogan { font-family: 'Alegreya SC', Georgia, Times, Times New Roman, Serif; }
+*/
 
 .maintenance-page #site-name, .maintenance-page h1, body.maintenance-page, .maintenance-page #site-slogan { font-family: 'Lato', Helvetica Neue, Arial, Sans-serif; }
 
@@ -101,18 +105,40 @@ body.pff-31, .pff-31 input, .pff-31 select, .pff-31 textarea, .pff-31 blockquote
 	.form-text, .form-textarea, .block-superfish select, .block-search .form-submit, #search-block-form .form-submit { background-image: none; } 
 }
 
-body { font-size: 15px; font-weight: 400; line-height: 1.45; color: #1e1e1e; }
+body {
+    font-family: 'Work Sans', sans-serif;
+    font-size: 1rem; /* Original was 15px */
+    line-height: 1.6; /* Original was 1.45 */
+    color: #212529; /* Original was #1e1e1e, this is Bootstrap's default body color */
+    font-weight: 400; /* This was the original default weight */
+    background-color: #fff; /* Ensure body background is white */
+}
 
 p { margin: 0; padding: 0 0 15px 0; }
 
 p.large { font-size: 21px; line-height: 1.33; }
 
-a { -webkit-transition: all 0.2s ease-in-out; -moz-transition: all 0.2s ease-in-out; -ms-transition: all 0.2s ease-in-out; 
--o-transition: all 0.2s ease-in-out; transition: all 0.2s ease-in-out; color: #2a68af; }
+a {
+    color: #2962ff; /* New link color */
+    text-decoration: none; /* Remove default underline */
+    /* Keep existing transition properties if they exist, or add: */
+    -webkit-transition: all 0.2s ease-in-out;
+    -moz-transition: all 0.2s ease-in-out;
+    -ms-transition: all 0.2s ease-in-out;
+    -o-transition: all 0.2s ease-in-out;
+    transition: all 0.2s ease-in-out;
+}
 
-a:hover { text-decoration: underline; color: #4187d1; }
+a:hover {
+    color: #1a237e; /* Slightly darker blue or a theme color for hover */
+    text-decoration: underline; /* Add underline on hover */
+}
 
-a:focus { outline: none; text-decoration: none; color: #4187d1; }
+a:focus { /* Adjusted to match hover for consistency */
+    outline: none; /* Common reset */
+    text-decoration: underline;
+    color: #1a237e; 
+}
 
 img {  height: auto; max-width: 100%; }
 
@@ -154,36 +180,46 @@ font-style: normal; font-size: 160px; line-height: 1; }
 hr { border-top: 1px solid #c2c2c2; margin-bottom: 40px; margin-top: 40px; }
 
 /*Headings*/
-h1, h2, h3, h4, h5, h6 { line-height: 1.20; padding: 0; margin: 20px 0 10px 0; font-weight: 700; text-transform: uppercase; }
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'League Spartan', sans-serif;
+    font-weight: 700;
+    line-height: 1.2;
+    color: #1a237e; /* New heading color */
+    margin-top: 0; 
+    margin-bottom: 0.5rem; /* Consistent spacing */
+}
 
-h1 a, h2 a, h3 a, h4 a, h5 a, h6 a { color: #1e1e1e; }
+h1 { font-size: 2.5rem; } /* Adjusted for Bootstrap 5 feel, original: 35px */
+h2 { font-size: 2rem; }   /* Adjusted, original: 28px */
+h3 { font-size: 1.75rem; }/* Adjusted, original: 21px */
+h4 { font-size: 1.5rem; } /* Adjusted, original: 19px */
+h5 { font-size: 1.25rem; }/* Adjusted, original: 16px */
+h6 { font-size: 1rem; }   /* New definition for h6 */
 
-h1 a:hover, h2 a:hover, h3 a:hover, h4 a:hover, h5 a:hover, h6 a:hover { color: #4187d1; }
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+    color: inherit; /* Headings links will inherit the heading color */
+    text-decoration: none;
+}
 
-h1 { font-size: 35px; }
+h1 a:hover, h2 a:hover, h3 a:hover, h4 a:hover, h5 a:hover, h6 a:hover {
+    color: #2962ff; /* Link hover color for headings */
+    text-decoration: underline;
+}
 
-h2 { font-size: 28px; font-weight: 400; }
+h1.title { margin-top:0; margin-bottom: 20px; } /* Retaining this specific rule for now */
 
-h3 { font-size: 21px; }
+.footer-area h2.title { font-size: 16px; margin-bottom: 15px; } /* Retaining for now */
 
-h4 { font-size: 19px; }
+#block-views-mt-latest-news-block-1 h2 { font-size: 24px; font-weight: 700; } /* Retaining for now */
 
-h5 { font-size: 16px; }
+.footer-area h1, .footer-area h2, .footer-area h3, .footer-area h4, .footer-area h5, .footer-area h6 { color: #fff; } /* Retaining for now */
 
-h1.title { margin-top:0; margin-bottom: 20px; }
-
-.footer-area h2.title { font-size: 16px; margin-bottom: 15px; }
-
-#block-views-mt-latest-news-block-1 h2 { font-size: 24px; font-weight: 700; }
-
-.footer-area h1, .footer-area h2, .footer-area h3, .footer-area h4, .footer-area h5, .footer-area h6 { color: #fff; }
-
-.footer-area h1 a, .footer-area h2 a, .footer-area h3 a, .footer-area h4 a, .footer-area h5 a, .footer-area h6 a { color: #fff; }
+.footer-area h1 a, .footer-area h2 a, .footer-area h3 a, .footer-area h4 a, .footer-area h5 a, .footer-area h6 a { color: #fff; } /* Retaining for now */
 
 .footer-area h1 a:hover, .footer-area h2 a:hover, .footer-area h3 a:hover, 
-.footer-area h4 a:hover, .footer-area h5 a:hover, .footer-area h6 a:hover{ color: #4187d1; }
+.footer-area h4 a:hover, .footer-area h5 a:hover, .footer-area h6 a:hover{ color: #2962ff; } /* Updated hover color */
 
-.subtitle { margin-top: -10px; text-transform: uppercase; padding-bottom: 20px; }
+.subtitle { margin-top: -10px; text-transform: uppercase; padding-bottom: 20px; } /* Retaining for now */
 
 .footer-area .subtitle { font-size: 12px; }
 
@@ -249,11 +285,17 @@ h1.title { margin-top:0; margin-bottom: 20px; }
 	#page-intro-inside { position: relative; bottom:0; border-bottom: 1px solid #cfd0d2; }
 }
 
-#highlighted { padding: 50px 0 0; }
+#highlighted { 
+    padding: 50px 0 0; 
+    background-color: #fff; /* Ensure highlighted section has a light background */
+}
 
 #highlighted + #main-content { padding: 20px 0; }
 
-#main-content { padding: 60px 0; }
+#main-content { 
+    /* padding: 60px 0; */ /* Removed as py-5 is applied to the inner container */
+    background-color: #fff; /* Ensure main content has a light background */
+}
 
 #promoted { padding: 0 0 20px 0; }
 
@@ -264,26 +306,36 @@ h1.title { margin-top:0; margin-bottom: 20px; }
 	#sidebar-first { margin-top: 0; }
 }
 
-#bottom-content { padding: 30px 0 30px; background: #f2f2f2; margin: 40px 0 0 0; }
-
-#footer-top { padding-top: 20px; background: #c2c2c2; }
-
-@media (min-width: 768px) {
-	#footer-top.two-regions { 
-		background: #c2c2c2; 
-		background: -moz-linear-gradient(left, #c2c2c2 50%, #d7d7d7 50%); 
-		background: -webkit-gradient(left, #c2c2c2 50%, #d7d7d7 50%);
-		background: -webkit-linear-gradient(left, #c2c2c2 49.7%, #d7d7d7 49.7%);
-		background: -o-linear-gradient(left, #c2c2c2 50%, #d7d7d7 50%);
-		background: -ms-linear-gradient(left, #c2c2c2 50%, #d7d7d7 50%);
-		background: linear-gradient(left, #c2c2c2 50%, #d7d7d7 50%);
-	}
-	#footer-top.one-region { background: #c2c2c2; }
+#bottom-content { 
+    padding: 30px 0 30px; 
+    background: #f8f9fa; /* Standard light gray, was #f2f2f2 */
+    margin: 40px 0 0 0; 
 }
 
-#footer { background-color: #101010; padding: 25px 0 55px 0; }
+#footer-top { 
+    padding: 3rem 0; /* py-5 equivalent */
+    background: #212529; 
+    color: #adb5bd; 
+}
 
-#subfooter { background-color: #080808; padding: 25px 0 15px; }
+@media (min-width: 768px) {
+	#footer-top.two-regions {  
+		background: #212529; /* Unified dark background */
+	}
+	#footer-top.one-region { 
+        background: #212529; /* Unified dark background */
+    }
+}
+
+#footer { 
+    background-color: #212529; /* Was #101010, now consistent dark */
+    padding: 3rem 0; /* Was 25px 0 55px 0 */
+}
+
+#subfooter { 
+    background-color: #212529; /* Was #080808, now consistent dark */
+    padding: 2rem 0; /* Was 25px 0 15px */
+}
 
 @media (min-width: 1200px) { 
 	.fix-sidebar-second { padding-left: 45px; }
@@ -295,7 +347,26 @@ h1.title { margin-top:0; margin-bottom: 20px; }
 .header-top-area { color: #fff; }
 
 /*Footer*/
-.footer-area, .subfooter-area { color: #a3a3a3; font-size: 14px; }
+.footer-area, .subfooter-area { 
+    color: #adb5bd; /* Was #a3a3a3. New default light text for footers. */
+    font-size: 0.9rem; /* Slightly smaller for footer */
+}
+#footer-top, #footer, #subfooter {
+    color: #adb5bd; /* General text color for all footer sections */
+}
+#footer-top h2.title, #footer h2.title, #subfooter h2.title,
+.footer-area h1, .footer-area h2, .footer-area h3, .footer-area h4, .footer-area h5, .footer-area h6 { 
+    color: #f8f9fa; /* Brighter color for headings in footer */
+}
+.footer-area h1 a, .footer-area h2 a, .footer-area h3 a, .footer-area h4 a, .footer-area h5 a, .footer-area h6 a {
+    color: #f8f9fa; /* Ensure heading links are also bright */
+}
+.footer-area h1 a:hover, .footer-area h2 a:hover, .footer-area h3 a:hover, 
+.footer-area h4 a:hover, .footer-area h5 a:hover, .footer-area h6 a:hover { 
+    color: #fff; /* Slightly brighter on hover for heading links */
+    text-decoration: underline;
+}
+
 
 @media (max-width: 767px) {
 	.footer-area { text-align: center; }
@@ -492,16 +563,33 @@ ul.menu li > a:hover:before { left: 10px; color: #2a68af!important; }
 ul.menu li.expanded > a:hover:before { left: 5px; }
 
 /*footer menu*/
-.footer-area ul.menu li a { color: #a3a3a3; padding: 7px 0 8px 25px; text-decoration: none; }
+.footer-area ul.menu li a { 
+    color: #dee2e6; /* Light link color */
+    padding: 7px 0 8px 25px; 
+    text-decoration: none; 
+}
 
-.footer-area ul.menu li a:hover { color: #4187d1; text-decoration: underline; background-color: transparent; }
+.footer-area ul.menu li a:hover,
+.footer-area ul.menu li a:focus { 
+    color: #fff; /* Brighter on hover/focus */
+    text-decoration: underline; 
+    background-color: transparent; 
+}
 
 /*footer menu arrows  */
-.footer-area ul.menu li > a:before { top:7px; }
+.footer-area ul.menu li > a:before { 
+    top:7px; 
+    color: #dee2e6; /* Match link color */
+}
 
-.footer-area ul.menu li > a:hover:before { left: 5px; }
+.footer-area ul.menu li > a:hover:before { 
+    left: 5px; 
+    color: #fff !important; /* Brighter arrow on hover */
+}
 
-.footer-area ul.menu li.active-trail > a:before { color: #2a68af; }
+.footer-area ul.menu li.active-trail > a:before { 
+    color: #fff; /* Active trail arrow color */
+}
 
 @media (max-width: 767px) {
 	.footer-area ul.menu { text-align: center; padding: 0 0 0 2px; }
@@ -516,14 +604,30 @@ ul.menu li.expanded > a:hover:before { left: 5px; }
 
 #subfooter ul.menu ul.menu { display: none; }
 
-#subfooter ul.menu li a { font-size: 12px; font-weight:700; text-transform:uppercase; margin:0; color: #a3a3a3; 
-padding: 0 10px 0 8px; border-right: 1px solid #a3a3a3;  line-height: 1; }  
+#subfooter ul.menu li a { 
+    font-size: 0.85rem; /* Slightly smaller */
+    font-weight:400; /* Normal weight */
+    text-transform:none; /* No uppercase */
+    margin:0; 
+    color: #dee2e6; 
+    padding: 0 10px 0 8px; 
+    border-right: 1px solid #495057;  /* Darker border for subtle separation */
+    line-height: 1; 
+}  
 
-#subfooter ul.menu li.last a { border-right: none; padding-right: 0; }
+#subfooter ul.menu li.last a { 
+    border-right: none; 
+    padding-right: 0; 
+}
 
-#subfooter ul.menu li a:hover { color: #ffffff; background-color: transparent; text-decoration: underline;}
+#subfooter ul.menu li a:hover,
+#subfooter ul.menu li a:focus { 
+    color: #fff; 
+    background-color: transparent; 
+    text-decoration: underline;
+}
 
-#subfooter ul.menu li.expanded > a:before, #subfooter ul.menu li > a:before { content: ""; }
+#subfooter ul.menu li.expanded > a:before, #subfooter ul.menu li > a:before { content: ""; } /* Keep arrows off for subfooter simple menu */
 
 @media (max-width: 991px) { 
 	#subfooter ul.menu { text-align: center; padding: 0 0 0 2px; }
@@ -635,22 +739,108 @@ width: 55px; background-color: #cfd0d2; height: 50px; position: absolute; bottom
 /*Node*/
 article.node { position: relative; }
 
-.node.node-teaser { margin-bottom: 55px; }
+/* Card Styling for .node-teaser */
+article.node.node-teaser {
+    margin-bottom: 1.5rem; /* mb-4 */
+    border: 1px solid #e0e0e0; /* New border */
+    box-shadow: 0 2px 5px rgba(0,0,0,0.05); /* New shadow */
+    background-color: #fff; /* Ensure light background */
+    border-radius: 0.375rem; /* Rounded corners */
+    overflow: hidden; /* Contain child elements */
+    display: flex; /* Added for flex layout if needed, or can be removed if causing issues */
+    flex-direction: column; /* Ensure content flows top to bottom */
+}
 
-.node.node-teaser header { padding-bottom: 10px; }
+/* Header within .node-teaser */
+.node.node-teaser header { 
+    padding: 1.5rem 1.5rem 0; /* Consistent padding for all teaser headers */
+    /* Original padding-bottom: 10px from old rule is removed */
+}
+/* No specific rule for .node.node-teaser.node-mt header needed if padding is consistent. 
+   .post-submitted-info is absolute and does not affect this padding flow. */
 
-.node.node-teaser.node-mt .field-type-image { overflow: hidden; }
+/* Ensure images within teasers are responsive */
+article.node.node-teaser img {
+    max-width: 100%;
+    height: auto;
+}
 
-.node.node-teaser .node-main-content { padding: 0 0 10px 0; border-bottom: 1px solid #acacac; }
+/* Images intended as card top images (if any, this is a general rule for now) */
+article.node.node-teaser .field-type-image:first-child { /* If image is the first element */
+    margin-bottom: 0; /* Remove bottom margin if it's a card top image */
+    /* width: 100%; */ /* Optional: make it full width if it's a top image */
+}
+article.node.node-teaser .field-type-image {
+     margin-bottom: 1rem; /* Add some space if image is within content body */
+}
 
-.node.node-teaser ul.links { display: none; }
 
-.node header .user-picture { padding: 0 0 20px 0; }
+/* Specific handling for images in .node-mt layout (date on left) */
+article.node.node-teaser.node-mt .field-type-image { 
+    overflow: hidden; /* This was already there */
+    /* The float: left and margin-right: 20px is handled by the @media rule below */
+}
 
-.feed-icon { display: block; margin: 0px 0 40px; }
+
+/* Content area within the teaser */
+.node.node-teaser .node-main-content {
+    padding: 1.5rem; /* Base padding for teaser content */
+    border-bottom: none; /* Remove old border, card has its own */
+    flex-grow: 1; /* Allow content to take available space */
+}
+
+/* Remove top padding from .node-main-content if it directly follows a header */
+.node.node-teaser header + .node-main-content {
+    padding-top: 0; 
+}
+
+/* For .node-mt layout, ensure the .custom-width content respects the main padding rules, 
+   while margin-left handles the date column. Explicit padding-top here is removed
+   as it should be handled by the header + .node-main-content rule above. */
+.node.node-teaser.node-mt .node-main-content.custom-width {
+    margin-left: 75px; /* Retain margin for date column */
+    /* padding-top: 1.5rem; */ /* This would override the header + .node-main-content rule, remove */
+}
+
+
+/* Footer area for "Read More" links */
+article.node-teaser footer {
+    padding: 1rem 1.5rem 1.5rem; /* Adjusted top padding for footer */
+    margin-top: auto; /* Push footer to bottom */
+}
+
+article.node-teaser footer ul.links {
+    display: block; 
+    margin: 0; /* Reset margin */
+    padding: 0; /* Reset padding, handled by footer or li */
+    text-align: left; 
+}
+
+article.node-teaser footer ul.links li {
+    display: inline;
+    padding: 0;
+    margin: 0; 
+}
+
+article.node-teaser footer ul.links li.node-readmore a {
+    display: inline-block;
+    padding: 0.375rem 0.75rem;
+    text-decoration: none;
+    border-radius: 0.25rem;
+    /* color and hover color will be inherited from global 'a' styles */
+}
+
+article.node-teaser footer ul.links li.node-readmore a:hover {
+    text-decoration: underline;
+    background-color: #f8f9fa; /* Subtle background on hover */
+}
+
+.node header .user-picture { padding: 0 0 20px 0; } /* Unchanged */
+
+.feed-icon { display: block; margin: 0px 0 40px; } /* Unchanged */
 
 @media (min-width: 481px) { 
-	.node.node-teaser.node-mt .field-type-image { float: left; margin-right: 20px; }
+	.node.node-teaser.node-mt .field-type-image { float: left; margin-right: 20px; } /* Retained */
 }
 
 /*Node type: Blog & Article - Submitted info*/
@@ -1191,4 +1381,4 @@ ul.contextual-links li a { font-weight: 400; line-height: 1; text-decoration: no
 /*Maintenance-page*/
 .maintenance-page #header-top,.maintenance-page #subfooter { min-height: 60px; }
 
-.maintenance-page #footer-top { min-height: 40px; }
+.maintenance-page #footer-top { min-height: 40px; } /* Unchanged */


### PR DESCRIPTION
This commit implements the first several steps of a major styling overhaul for the Ciencia Aberta Ubatuba website.

Changes include:

1.  **Header & Navigation:**
    *   Replaced the old Bootstrap 3 header/top-bar with a new Bootstrap 5 responsive Navbar.
    *   The new navbar includes the site logo, main navigation links ("Início", "O projeto", "Blog", "Contato"), and a functional hamburger menu for mobile.
    *   Integrated a responsive search form and a language switcher dropdown into the navbar, both right-aligned.
    *   Removed the old `jquery.meanmenu.js` as Bootstrap 5 handles mobile collapse.
    *   Updated `index.html` with the new Bootstrap 5 CSS and JS CDN links.

2.  **Typography & Base Styles:**
    *   Updated `style.css` to use 'Work Sans' for body text and 'League Spartan' for headings.
    *   Imported these fonts from Google Fonts with `font-display: swap`.
    *   Standardized base body `font-size` to `1rem`, `line-height` to `1.6`, and `color` to `#212529`.
    *   Defined consistent heading styles (font, weight, line-height, color `#1a237e`, margins).
    *   Updated global link styles for color (`#2962ff`) and hover/focus states.
    *   Removed old font-family theme classes (`pff-X`, `hff-X`) from `style.css` and `index.html`.

3.  **Color Palette & Section Backgrounds:**
    *   Set a consistent light background (`#fff` or `#f8f9fa`) for main content sections like `body`, `#main-content`, and `#highlighted` in `style.css`.
    *   Ensured accent colors (blues/greens) are primarily used for text elements (headings, links) rather than large backgrounds.
    *   The `#bottom-content` background was updated to `#f8f9fa`.
    *   Footer backgrounds were intentionally not changed in this step.

4.  **Spacing & Layout:**
    *   Applied Bootstrap's `py-5` class to the main content container in `index.html` for consistent vertical padding.
    *   Removed the corresponding custom padding from `#main-content` in `style.css`.
    *   Reviewed other general spacing rules in `style.css`, keeping most specific ones for now to manage scope.

5.  **Card Styling (Projetos, Blog, etc.):**
    *   Updated styles for `.node-teaser` elements in `style.css` to give them a modern card-like appearance.
    *   Added `margin-bottom`, `border`, `box-shadow`, `background-color`, and `border-radius`.
    *   Set `overflow: hidden` and `display: flex; flex-direction: column;` for better layout control.
    *   Standardized padding within card headers and content areas (`.node-main-content`).
    *   Ensured "Read More" links (`article.node-teaser footer ul.links li.node-readmore a`) are visible and styled more like buttons.
    *   Adjusted image margins within cards.

6.  **Footer Styling:**
    *   Standardized the backgrounds of `#footer-top`, `#footer` (via `.footer-area`), and `#subfooter` to a consistent dark color (`#212529`).
    *   Updated text and link colors in these footer sections to ensure good contrast (light text/links on dark background).
    *   Applied consistent vertical padding to footer sections (`3rem` or `2rem`).

**Current Status & Next Steps:**
I was proceeding according to my plan. The immediate next step was to perform a general responsiveness review of the changes made so far. After that, I planned to focus on lightweighting (image optimization, CSS minification).

I was in the process of initiating the "General Responsiveness" review by reloading the modified files to analyze them. I hadn't encountered any specific issues that caused me to get stuck, but the responsiveness review itself was not yet performed.